### PR TITLE
Fix PrintClearLine to work in high res mode

### DIFF
--- a/saturnringlib/srl_debug.hpp
+++ b/saturnringlib/srl_debug.hpp
@@ -174,7 +174,7 @@ namespace SRL
          */
         inline static void PrintClearLine(const uint8_t line)
         {
-            for (int x = 0; x < 40; x++)
+            for (int x = 0; x < 44; x++)
             {
                 Debug::Print(x, line, " ");
             }


### PR DESCRIPTION
Previously, the last 4 characters were not cleared from the screen in high resolution/wide screen modes