### PR TITLE
Fix operator precedence bug for 64-color palettes

### DIFF
--- a/saturnringlib/srl_cram.hpp
+++ b/saturnringlib/srl_cram.hpp
@@ -241,7 +241,7 @@ namespace SRL
                     break;
                 
                 case CRAM::TextureColorMode::Paletted64:
-                    for (int32_t id = 0; id < 32 && freeBank < 0; (((uint8_t*)CRAM::AllocationMask)[id >> 1] & (id % 2 == 0 ? 0x0f : 0xf0) == 0) ? freeBank = id : id++);
+                    for (int32_t id = 0; id < 32 && freeBank < 0; ((((uint8_t*)CRAM::AllocationMask)[id >> 1] & (id % 2 == 0 ? 0x0f : 0xf0)) == 0) ? freeBank = id : id++);
                     break;
                 
                 case CRAM::TextureColorMode::Paletted16:


### PR DESCRIPTION
Resolves #77.

The issue only affects 64-color because it has a ternary operator that gets incorrectly grouped with the `== 0` comparison due to operator precedence shenanigans. That's why 16-color gets away without any issues.

Branch with bug and TGA test: https://github.com/sftwninja/SaturnRingLib/tree/demo/tga-palette-bug-broken
<img width="908" height="747" alt="tga_w_bug" src="https://github.com/user-attachments/assets/6c7c858b-4cd6-4aff-a320-3b07676a99cc" />

Branch with fix and TGA test: https://github.com/sftwninja/SaturnRingLib/tree/demo/tga-palette-bug-fixed
<img width="908" height="747" alt="tga_w_fix" src="https://github.com/user-attachments/assets/1f95e3c1-3adc-458c-a979-fadf78b95263" />
