### PR TITLE
(Enhancement) Implement RAW audio caching and sparse padding for sector-aligning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@
 **/cd/data/BIB.TXT
 **/cd/data/CPY.TXT
 
+# Audio raw files (generated from source audio)
+**/cd/music/*.raw
+
 /[Tt]ests/**/[Bb]uild[Dd]rop/**
 /[Tt]ests/**/*.o
 /[Tt]ests/**/*.log


### PR DESCRIPTION
Continuation of discussion in #80.

* Implements a tip from @willll from this [StackOverflow post](https://unix.stackexchange.com/a/196727) for doing sparse padding. The effect is fairly minor, but it's basically a free improvement.
* Leaves the RAW files intact in the audio directory so that subsequent builds use them _if_:
  * They exist. (obviously)
  * The RAW file was created _after_ the modification time of the original audio file it was generated from.
  * _Otherwise_, it generates or regenerates the RAW file.

I've gitignore'd these files by default since they're expensive in short term rapid development, but not so expensive they need to live in VCS.

Lastly, refactored the audio generation portion since it was starting to get very tendril-y. It should be more compact and isolated now.

Users shouldn't expect any differences in their usual workflows due to this change.