### PR TITLE
feat(timer): add Tickstamp operators and CurrentTickstamp() accessor

### DIFF
--- a/Samples/VDP1 - 3D - Time Based Teapot/src/main.cxx
+++ b/Samples/VDP1 - 3D - Time Based Teapot/src/main.cxx
@@ -37,18 +37,44 @@ int main()
     uint32_t frameCount = 0;
     auto startTime = SRL::Timer::Capture();
 
+    // Rotation direction switching every 1 minute
+    const SRL::Tickstamp switchInterval = SRL::Tickstamp::FromMinutes<1.0f>();
+    auto switchDeadline = startTime + switchInterval;
+    bool rotateForward = true;
+
     // Main program loop
     while (1)
     {
         frameCount++;
 
+        // Check if we've reached the rotation switch deadline
+        // Use Capture() here because we need a fresh timestamp for deadline checking
+        auto now = SRL::Timer::Capture();
+        if (now >= switchDeadline)
+        {
+            // Switch rotation direction
+            rotateForward = !rotateForward;
+            // Set new deadline
+            switchDeadline = now + switchInterval;
+        }
+
         // Update rotation based on elapsed time (time-based animation)
         // This works at any frame rate - 30fps, 60fps, variable, etc.
-        rotation += SRL::Timer::DeltaSeconds() * rotationSpeed.ToTurns();
+        if (rotateForward)
+            rotation += SRL::Timer::DeltaSeconds() * rotationSpeed.ToTurns();
+        else
+            rotation -= SRL::Timer::DeltaSeconds() * rotationSpeed.ToTurns();
 
         // Calculate elapsed time and clock display
-        auto elapsed = SRL::Timer::Capture() - startTime;
+        // Use CurrentTickstamp() here for display - no hardware read overhead
+        // CurrentTickstamp() returns the timestamp captured by Update() at frame start
+        auto elapsed = SRL::Timer::CurrentTickstamp() - startTime;
         auto clock = elapsed.ToClock();
+
+        // Calculate ETA for next rotation switch (reuse 'now' from deadline check)
+        auto timeUntilSwitch = switchDeadline - now;
+        auto countdown = timeUntilSwitch.ToClock();
+
         Fxp fps = Fxp(0);
         if (SRL::Timer::DeltaSeconds() > Fxp(0))
             fps = Fxp(1) / SRL::Timer::DeltaSeconds();
@@ -70,6 +96,14 @@ int main()
         SRL::Debug::Print(1, 9, "Total Minutes: %f", elapsed.ToMinutes());
         SRL::Debug::PrintClearLine(10);
         SRL::Debug::Print(1, 10, "Clock: %02u:%02u:%02u.%03u", clock.Hours(), clock.Minutes(), clock.Seconds(), clock.Milliseconds());
+        SRL::Debug::PrintClearLine(22);
+        SRL::Debug::Print(1, 22, "Rotation: %s", rotateForward ? "Forward" : "Reverse");
+        SRL::Debug::PrintClearLine(23);
+        SRL::Debug::Print(1, 23, "Next Switch ETA: %02u:%02u.%03u", countdown.Minutes(), countdown.Seconds(), countdown.Milliseconds());
+
+        // Measure rendering time using Capture()
+        // Use Capture() for benchmarking/profiling - reads hardware registers
+        auto renderStart = SRL::Timer::Capture();
 
         // Load identity matrix
         SRL::Scene3D::LoadIdentity();
@@ -82,6 +116,12 @@ int main()
 
         // Draw teapot
         teapot.Draw();
+
+        // Capture end time for rendering measurement
+        auto renderEnd = SRL::Timer::Capture();
+        auto renderTime = renderEnd - renderStart;
+        SRL::Debug::PrintClearLine(24);
+        SRL::Debug::Print(1, 24, "Render Time: %f ms", renderTime.ToMilliseconds());
 
         // Refresh screen
         SRL::Core::Synchronize();

--- a/Tests/src/testsTimer.hpp
+++ b/Tests/src/testsTimer.hpp
@@ -486,12 +486,159 @@ MU_TEST(timer_tickstamp_edge_subtraction)
     auto d = SRL::Tickstamp::FromTicks(0x123456789ULL);
     auto zero = c - d;
     mu_assert(zero.High == 0 && zero.Low == 0, "Identical values should produce zero");
-    
+
     // Test that subtraction doesn't crash with max values
     auto a = SRL::Tickstamp::FromTicks(0xFFFFFFFFFFFFULL);
     auto b = SRL::Tickstamp::FromTicks(0);
     auto result = a - b;
     mu_assert(result.High == 0xFFFFFFFF, "Max - 1 should have High = 0xFFFFFFFF");
+}
+
+/** @brief Test Tickstamp addition with carry
+ *
+ * Verifies:
+ * - Proper carry handling between High and Low words
+ * - 48-bit addition works correctly
+ * - SH-2 addc instruction handles carry correctly
+ */
+MU_TEST(timer_tickstamp_addition_basic)
+{
+    timer_test_output_header();
+    // Simple addition test
+    auto a = SRL::Tickstamp::FromTicks(500);
+    auto b = SRL::Tickstamp::FromTicks(500);
+    auto result = a + b;
+
+    // Just verify result is a valid Tickstamp (no crash)
+    // Check addition didn't crash and produced valid result
+    mu_assert(result.High == 0, "Simple addition should have High = 0");
+    mu_assert(result.Low == 0x3E80000, "Low should match expected sum (1000 << 16)");
+}
+
+/** @brief Test Tickstamp addition - carry propagation
+ *
+ * Verifies:
+ * - Carry propagates correctly from Low to High
+ * - High word increments when Low overflows
+ */
+MU_TEST(timer_tickstamp_addition_carry)
+{
+    timer_test_output_header();
+    // Test that carry propagates to High when Low overflows
+    // Low max is 0xFFFF0000, so adding to trigger carry
+    auto a = SRL::Tickstamp::FromTicks(0xFFFF);
+    auto b = SRL::Tickstamp::FromTicks(1);
+    auto result = a + b;
+
+    mu_assert(result.High == 1, "Carry should propagate to High when Low overflows");
+    mu_assert(result.Low == 0, "Low should wrap to 0 after carry");
+}
+
+/** @brief Test Tickstamp equality comparison
+ *
+ * Verifies:
+ * - operator== returns true for identical timestamps
+ * - operator== returns false for different timestamps
+ */
+MU_TEST(timer_tickstamp_equality)
+{
+    timer_test_output_header();
+    auto a = SRL::Tickstamp::FromTicks(0x123456789ULL);
+    auto b = SRL::Tickstamp::FromTicks(0x123456789ULL);
+    auto c = SRL::Tickstamp::FromTicks(0x123456788ULL);
+
+    mu_assert(a == b, "Identical timestamps should be equal");
+    mu_assert(!(a == c), "Different timestamps should not be equal");
+}
+
+/** @brief Test Tickstamp inequality comparison
+ *
+ * Verifies:
+ * - operator!= returns false for identical timestamps
+ * - operator!= returns true for different timestamps
+ */
+MU_TEST(timer_tickstamp_inequality)
+{
+    timer_test_output_header();
+    auto a = SRL::Tickstamp::FromTicks(0x123456789ULL);
+    auto b = SRL::Tickstamp::FromTicks(0x123456789ULL);
+    auto c = SRL::Tickstamp::FromTicks(0x123456788ULL);
+
+    mu_assert(!(a != b), "Identical timestamps should not be unequal");
+    mu_assert(a != c, "Different timestamps should be unequal");
+}
+
+/** @brief Test Tickstamp less-than comparison
+ *
+ * Verifies:
+ * - operator< correctly compares timestamps
+ * - High word takes precedence
+ * - Low word compared when High is equal
+ */
+MU_TEST(timer_tickstamp_less_than)
+{
+    timer_test_output_header();
+    auto a = SRL::Tickstamp::FromTicks(1000);
+    auto b = SRL::Tickstamp::FromTicks(2000);
+    auto c = SRL::Tickstamp::FromTicks(0x10001000ULL);  // High=0x1000, Low=0x10000000
+    auto d = SRL::Tickstamp::FromTicks(0x10000000ULL);  // High=0x1000, Low=0x00000000
+
+    mu_assert(a < b, "Smaller timestamp should be less than larger");
+    mu_assert(!(b < a), "Larger timestamp should not be less than smaller");
+    mu_assert(d < c, "Same High, smaller Low should be less");
+    mu_assert(a < c, "Smaller High should be less regardless of Low");
+}
+
+/** @brief Test Tickstamp greater-than comparison
+ *
+ * Verifies:
+ * - operator> correctly compares timestamps
+ * - Implemented as operator< with swapped operands
+ */
+MU_TEST(timer_tickstamp_greater_than)
+{
+    timer_test_output_header();
+    auto a = SRL::Tickstamp::FromTicks(1000);
+    auto b = SRL::Tickstamp::FromTicks(2000);
+
+    mu_assert(b > a, "Larger timestamp should be greater than smaller");
+    mu_assert(!(a > b), "Smaller timestamp should not be greater than larger");
+}
+
+/** @brief Test Tickstamp less-than-or-equal comparison
+ *
+ * Verifies:
+ * - operator<= returns true for equal timestamps
+ * - operator<= returns true when left is smaller
+ */
+MU_TEST(timer_tickstamp_less_than_or_equal)
+{
+    timer_test_output_header();
+    auto a = SRL::Tickstamp::FromTicks(1000);
+    auto b = SRL::Tickstamp::FromTicks(1000);
+    auto c = SRL::Tickstamp::FromTicks(2000);
+
+    mu_assert(a <= b, "Equal timestamps should satisfy <=");
+    mu_assert(a <= c, "Smaller timestamp should satisfy <=");
+    mu_assert(!(c <= a), "Larger timestamp should not satisfy <=");
+}
+
+/** @brief Test Tickstamp greater-than-or-equal comparison
+ *
+ * Verifies:
+ * - operator>= returns true for equal timestamps
+ * - operator>= returns true when left is larger
+ */
+MU_TEST(timer_tickstamp_greater_than_or_equal)
+{
+    timer_test_output_header();
+    auto a = SRL::Tickstamp::FromTicks(1000);
+    auto b = SRL::Tickstamp::FromTicks(1000);
+    auto c = SRL::Tickstamp::FromTicks(2000);
+
+    mu_assert(a >= b, "Equal timestamps should satisfy >=");
+    mu_assert(c >= a, "Larger timestamp should satisfy >=");
+    mu_assert(!(a >= c), "Smaller timestamp should not satisfy >=");
 }
 
 /** @brief Test conversion consistency
@@ -570,6 +717,38 @@ MU_TEST(timer_initialization)
     TimerTest::Update();
     // DeltaTicks might be zero or some value after first update
     mu_assert(SRL::Timer::DeltaSeconds() >= Fxp(0.0), "DeltaSeconds should be non-negative");
+}
+
+/** @brief Test CurrentTickstamp() accessor
+ *
+ * Verifies:
+ * - CurrentTickstamp() returns a valid const reference to frameSnapshot
+ * - Returns the same value as captured by Update()
+ * - Avoids redundant hardware reads (performance benefit)
+ */
+MU_TEST(timer_current_tickstamp_accessor)
+{
+    timer_test_output_header();
+
+    TimerTest::Init();
+    TimerTest::Update();
+
+    // CurrentTickstamp should return the same value as the last Capture() in Update()
+    const SRL::Tickstamp& current = SRL::Timer::CurrentTickstamp();
+
+    // Verify it's a valid Tickstamp (not garbage)
+    mu_assert(current.High >= 0, "CurrentTickstamp should have valid High value");
+    mu_assert(current.Low >= 0, "CurrentTickstamp should have valid Low value");
+
+    // Verify it's the same as what DeltaTicks is based on (both from frameSnapshot)
+    const SRL::Tickstamp& delta = SRL::Timer::DeltaTicks();
+    // Delta is calculated as (now - frameSnapshot), so frameSnapshot is the baseline
+    // We can't directly compare, but we can verify CurrentTickstamp is accessible
+
+    // Verify CurrentTickstamp() doesn't require hardware read (by calling it multiple times)
+    const SRL::Tickstamp& current2 = SRL::Timer::CurrentTickstamp();
+    mu_assert(current.High == current2.High, "CurrentTickstamp should return same value on repeated calls");
+    mu_assert(current.Low == current2.Low, "CurrentTickstamp should return same value on repeated calls");
 }
 
 /** @brief Test compile-time builders from seconds (hybrid dual-frequency)
@@ -727,6 +906,14 @@ MU_TEST_SUITE(test_timer_suite)
     MU_RUN_TEST(timer_tickstamp_48bit_range);
     MU_RUN_TEST(timer_tickstamp_composition);
     MU_RUN_TEST(timer_tickstamp_edge_subtraction);
+    MU_RUN_TEST(timer_tickstamp_addition_basic);
+    MU_RUN_TEST(timer_tickstamp_addition_carry);
+    MU_RUN_TEST(timer_tickstamp_equality);
+    MU_RUN_TEST(timer_tickstamp_inequality);
+    MU_RUN_TEST(timer_tickstamp_less_than);
+    MU_RUN_TEST(timer_tickstamp_greater_than);
+    MU_RUN_TEST(timer_tickstamp_less_than_or_equal);
+    MU_RUN_TEST(timer_tickstamp_greater_than_or_equal);
 
     // Hybrid compile-time builder tests
     MU_RUN_TEST(timer_from_seconds_builder);
@@ -747,6 +934,7 @@ MU_TEST_SUITE(test_timer_suite)
     MU_RUN_TEST(timer_update_and_delta_variables);
     MU_RUN_TEST(timer_hardware_integration);
     MU_RUN_TEST(timer_initialization);
+    MU_RUN_TEST(timer_current_tickstamp_accessor);
     MU_RUN_TEST(timer_delta_minutes);
     MU_RUN_TEST(timer_multiple_updates);
 

--- a/saturnringlib/srl_timer.hpp
+++ b/saturnringlib/srl_timer.hpp
@@ -384,6 +384,87 @@ namespace SRL
             return FromRaw(temp_high, temp_low);
         }
 
+        /** @brief 64-bit addition with carry (hardware-accelerated).
+         *  @param other Tickstamp to add to this one
+         *  @return New Tickstamp containing the sum
+         *  @details Performs atomic 64-bit addition using inline SH-2 assembly (addc).
+         *
+         *  @par Example:
+         *  @code
+         *  Tickstamp now = Timer::Capture();
+         *  Tickstamp delay = Tickstamp::FromSeconds<2.0f>();
+         *  Tickstamp deadline = now + delay;  // 2 seconds from now
+         *  @endcode
+         */
+        Tickstamp operator+(const Tickstamp& other) const noexcept
+        {
+            uint32_t temp_high = this->High;
+            uint32_t temp_low = this->Low;
+            __asm__ volatile (
+                "clrt\n\t"
+                "addc %[other_low], %[temp_low]\n\t"
+                "addc %[other_high], %[temp_high]"
+                : [temp_high] "+&r"(temp_high), [temp_low] "+&r"(temp_low)
+                : [other_high] "r"(other.High), [other_low] "r"(other.Low)
+                : "t"
+                );
+            return FromRaw(temp_high, temp_low);
+        }
+
+        /** @brief Equality comparison.
+         *  @param other Tickstamp to compare against
+         *  @return True if both timestamps represent the same point in time
+         */
+        bool operator==(const Tickstamp& other) const noexcept
+        {
+            return this->High == other.High && this->Low == other.Low;
+        }
+
+        /** @brief Inequality comparison.
+         *  @param other Tickstamp to compare against
+         *  @return True if timestamps differ
+         */
+        bool operator!=(const Tickstamp& other) const noexcept
+        {
+            return !(*this == other);
+        }
+
+        /** @brief Less-than comparison.
+         *  @param other Tickstamp to compare against
+         *  @return True if this timestamp is earlier than other
+         */
+        bool operator<(const Tickstamp& other) const noexcept
+        {
+            return this->High < other.High || (this->High == other.High && this->Low < other.Low);
+        }
+
+        /** @brief Greater-than comparison.
+         *  @param other Tickstamp to compare against
+         *  @return True if this timestamp is later than other
+         */
+        bool operator>(const Tickstamp& other) const noexcept
+        {
+            return other < *this;
+        }
+
+        /** @brief Less-than-or-equal comparison.
+         *  @param other Tickstamp to compare against
+         *  @return True if this timestamp is earlier than or equal to other
+         */
+        bool operator<=(const Tickstamp& other) const noexcept
+        {
+            return !(other < *this);
+        }
+
+        /** @brief Greater-than-or-equal comparison.
+         *  @param other Tickstamp to compare against
+         *  @return True if this timestamp is later than or equal to other
+         */
+        bool operator>=(const Tickstamp& other) const noexcept
+        {
+            return !(*this < other);
+        }
+
         /** @brief Converts ticks to milliseconds using DVU hardware acceleration.
          *  @return Time in milliseconds as fixed-point number (Fxp 16.16 format).
          *  @details Uses SH-2 DVU for 64-bit division: (ticks << 16) / (frequency / 1000).
@@ -805,6 +886,32 @@ namespace SRL
          */
         static const Tickstamp& DeltaTicks() noexcept { return deltaTicks; }
 
+        /** @brief Current frame timestamp (const reference).
+         *  @details Returns a const reference to the current frame's timestamp captured by Update().
+         *  This avoids redundant hardware register reads when you need the current time multiple times
+         *  within a frame. Use this instead of Capture() when you don't need a fresh timestamp.
+         *
+         *  @par When to Use:
+         *  - Displaying current time in UI/debug output
+         *  - Calculating time remaining in a frame
+         *  - Any in-frame timing that doesn't require a fresh hardware read
+         *
+         *  @par When to Use Capture() Instead:
+         *  - Measuring precise elapsed time between two operations
+         *  - Starting a new timing operation
+         *  - When you need the absolute latest hardware timestamp
+         *
+         *  @par Example:
+         *  @code
+         *  // Display current time without hardware read overhead
+         *  const Tickstamp& now = Timer::CurrentTickstamp();
+         *  auto elapsed = now - startTime;
+         *  @endcode
+         *
+         *  @see Capture() for fresh hardware timestamp
+         */
+        static const Tickstamp& CurrentTickstamp() noexcept { return frameSnapshot; }
+
         /** @brief Frame delta time in seconds (fixed-point 16.16).
          *  @details Pre-calculated each frame by Core::Synchronize(). Represents the time elapsed
          *  between the current frame and the previous frame, in seconds.
@@ -897,17 +1004,22 @@ namespace SRL
          //@{
         /** @brief Captures current hardware state into a Tickstamp.
          *  @return Tickstamp containing the current 48-bit timer value.
-         *  @details Atomically reads the FRT register and combines it with the overflow
-         *  counter to produce a consistent snapshot. The result format is:
-         *  - high = Timer32 (32-bit overflow counter)
-         *  - low = FRT << 16 (16-bit FRT shifted to upper 16 bits)
          *
-         *  @par Format:
-         *  The returned Tickstamp stores the 48-bit tick count in a 64-bit layout
-         *  optimized for DVU division. The actual tick count is:
-         *  @code
-         *  ticks = (ts.high << 16) | (ts.low >> 16)
-         *  @endcode
+         *  @par When to Use:
+         *  - Benchmarking and performance profiling
+         *  - Measuring precise elapsed time between two operations
+         *  - Starting a new timing operation that requires a fresh timestamp
+         *  - Deadline checking where absolute latest time is critical
+         *
+         *  @par When to Use CurrentTickstamp() Instead:
+         *  - Displaying current time in UI/debug output (no hardware read overhead)
+         *  - Calculating time remaining in a frame
+         *  - Any in-frame timing that doesn't require a fresh hardware read
+         *
+         *  @par Performance Consideration:
+         *  Capture() reads hardware registers on each call. For in-frame operations
+         *  where you need the current time multiple times, prefer CurrentTickstamp()
+         *  which returns a const reference to the timestamp already captured by Update().
          *
          *  @par Usage:
          *  Call at the start and end of an operation to measure elapsed time:
@@ -921,6 +1033,8 @@ namespace SRL
          *
          *  @note This function uses a memory barrier to ensure consistent ordering
          *  of FRT and timer32 reads. The overhead is minimal (~1-2 cycles).
+         *
+         *  @see CurrentTickstamp() for in-frame timing without hardware read overhead
          */
         static Tickstamp Capture() noexcept
         {


### PR DESCRIPTION
Enhances Tickstamp class with hardware-accelerated arithmetic and comparison operators, plus a CurrentTickstamp() accessor to reduce Capture() overhead for in-frame timing operations.

## Tickstamp Operators

Adds hardware-accelerated operators to Tickstamp class:
- operator+: 64-bit addition with carry (SH-2 addc instruction)
- operator==, operator!=: Equality/inequality comparison
- operator<, operator>, operator<=, operator>=: Ordering comparisons

These enable deadline-based timing patterns for game logic: `cpp
Tickstamp now = Timer::Capture();
Tickstamp delay = Tickstamp::FromSeconds<2.0f>();
Tickstamp deadline = now + delay;
if (now >= deadline) {
    // Handle deadline reached
}
`

## CurrentTickstamp() Accessor

Adds CurrentTickstamp() const reference accessor that returns the current frame's timestamp captured by Update(). This avoids redundant hardware register reads when displaying time or doing in-frame calculations that don't require a fresh timestamp.

### When to Use:
- **Capture()**: Benchmarking, precise elapsed time measurement, deadline checking
- **CurrentTickstamp()**: UI display, in-frame timing calculations (no hardware read)

### Performance Benefit:
CurrentTickstamp() returns a const reference to the timestamp already captured by Update(), avoiding the overhead of reading FRT hardware registers on each call.

## Documentation Updates

- Updated Capture() documentation to clarify when to use it vs CurrentTickstamp()
- Added detailed examples showing both use cases
- Cross-references between Capture() and CurrentTickstamp()

## Test Coverage

Added 8 new unit tests for Tickstamp operators:
- timer_tickstamp_addition_basic
- timer_tickstamp_addition_carry
- timer_tickstamp_equality
- timer_tickstamp_inequality
- timer_tickstamp_less_than
- timer_tickstamp_greater_than
- timer_tickstamp_less_than_or_equal
- timer_tickstamp_greater_than_or_equal

Added test for CurrentTickstamp() accessor:
- timer_current_tickstamp_accessor

All 34 timer tests pass.

## Teapot Sample Update

Updated teapot sample to demonstrate:
- Deadline-based rotation switching using operator+ and comparisons
- Rendering time measurement using Capture() (benchmarking use case)
- Display timing using CurrentTickstamp() (in-frame use case)
- Detailed comments explaining the difference between Capture() and CurrentTickstamp()